### PR TITLE
Fixed mistake in build instructions

### DIFF
--- a/README
+++ b/README
@@ -129,7 +129,7 @@ changing the device type for which to build.
 To install Kokkos as a library create a build directory and run the following
 
 KOKKOS_PATH/generate_makefile.bash --prefix=INSTALL_PATH
-make lib
+make kokkoslib
 make install
 
 KOKKOS_PATH/generate_makefile.bash --help for more detailed options such as


### PR DESCRIPTION
At some point `make lib` became `make kokkoslib`